### PR TITLE
feat: Add method for finding related skills

### DIFF
--- a/lib/api/skills.js
+++ b/lib/api/skills.js
@@ -69,3 +69,26 @@ exports.skillById = async (skillId, version = "latest") => {
     });
   });
 };
+
+exports.relatedSkills = async (skillIds, version = "latest") => {
+  const token = await getToken();
+  const options = {
+    method: "POST",
+    url: `https://skills.emsicloud.com/versions/${version}/related`,
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json"
+    },
+    body: { ids: skillIds },
+    json: true
+  };
+
+  return new Promise((resolve, reject) => {
+    request(options, function (error, response, body) {
+      if (error) {
+        reject(error);
+      }
+      resolve(JSON.parse(body));
+    });
+  });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "emsi-skills-api",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/skills.spec.js
+++ b/test/skills.spec.js
@@ -52,4 +52,17 @@ describe("skills", function () {
         return done();
       });
   });
+
+  it("fetches related skills", function (done) {
+    api.skills
+      .relatedSkills(["KS1200364C9C1LK3V5Q1"])
+      .then(response => {
+        expect(response).to.be.ok;
+        return done();
+      })
+      .catch((error) => {
+        expect(error).to.not.be.ok;
+        return done();
+      });
+  });
 });


### PR DESCRIPTION
This adds a method for hitting the related skills endpoint: https://api.emsidata.com/apis/skills#versions-version-related